### PR TITLE
jwt_sliding_expiration_middleware

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Request
 from sqlalchemy.orm import Session
 from app.core.database import SessionLocal
 from app.models.user import User
 from app.schemas.user import UserRegister, LoginRequest, TokenResponse
 from app.core.security import hash_password
-from app.core.auth import authenticate_user, create_access_token
+from app.core.auth import authenticate_user, create_access_token, get_current_user
+
 
 router = APIRouter()
 
@@ -42,3 +43,7 @@ async def login(data: LoginRequest, db: Session = Depends(get_db)):
         raise e
     token = create_access_token({"sub": user.email})
     return {"access_token": token}
+
+@router.get("/protected")
+def protected_endpoint(user=Depends(get_current_user)):
+    return {"message": "You are authenticated", "user": user}

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,7 @@
 from passlib.context import CryptContext
+from fastapi.security import HTTPBearer
+
+bearer_scheme = HTTPBearer()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/backend/app/core/sliding_expiration.py
+++ b/backend/app/core/sliding_expiration.py
@@ -1,0 +1,30 @@
+import logging
+from fastapi import Request, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+from app.core import auth
+
+logger = logging.getLogger("sliding_expiration")
+
+
+class SlidingExpirationMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header.split(" ")[1]
+
+            try:
+                payload, refreshed_token = auth.verify_and_refresh_token(token)
+                logger.info(f"Token verified for user: {payload.get('sub')}")
+                request.state.user = payload
+
+                response = await call_next(request)
+
+                response.headers["Authorization"] = f"Bearer {refreshed_token}"
+                return response
+
+            except HTTPException as e:
+                logger.warning(f"Token verification failed: {e.detail}")
+                raise
+        else:
+            logger.info("No Authorization header or wrong format")
+            return await call_next(request)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 from app.api import users
-
+from app.core.sliding_expiration import SlidingExpirationMiddleware
 
 
 app = FastAPI()
+
+app.add_middleware(SlidingExpirationMiddleware)
 
 @app.get("/health")
 def health_check():


### PR DESCRIPTION
core/sliding_expiration contains middleware which is responsible for refreshing token.
**feature can't be used with FastAPI docs - No "Authorization" header in request body**

For testing purposes, I added authorization in FastAPI docs. After logging in, paste the token from the response into the authorize field in the upper right corner.